### PR TITLE
Add Support for YDLIDAR X4 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and read this [blog post](https://kaia.ai/blog/arduino-lidar-library/) for more 
 Please visit the [Support Forum](https://github.com/makerspet/support/discussions/)!
 
 This library supports:
-- YDLIDAR X4, X3, X3-PRO, X2/X2L, SCL models
+- YDLIDAR X4, X4-PRO, X3, X3-PRO, X2/X2L, SCL models
 - SLAMTEC RPLIDAR A1
 - Neato XV11/Botvac
 - Xiaomi Roborock Mi 1st gen LDS02RR
@@ -79,6 +79,9 @@ Some LiDAR/LDS models do not have built-in motor control and therefore require a
 
 ## Release notes
 
+## v0.5.7
+- added YDLIDAR X4-PRO
+
 ## v0.5.6
 - added YDLIDAR SCL
 
@@ -130,7 +133,6 @@ Some LiDAR/LDS models do not have built-in motor control and therefore require a
 - add Xiaomi Roborock LDS01RR
 - add LDROBOT LD20
 - add LDROBIT LD19P, https://github.com/Myzhar/ldrobot-lidar-ros2
-- add YDLIDAR SCL
 - add Hitachi-LG HLS-LFCD2
 - add Dreame TBD
 - reduce raw data volume

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=LDS
-version=0.5.6
+version=0.5.7
 author=Ilia O. <iliao@kaia.ai>
 maintainer=Ilia O. <iliao@kaia.ai>
 sentence=Laser distance scan sensors (LDS/LIDAR) wrapper/controller for kaia.ai robotics platform
-paragraph=Supports YDLIDAR X4, X3, X3 PRO, X2/X2L, SCL; Xiaomi Roborock 1st gen LDS02RR; Neato XV11; SLAMTEC RPLIDAR A1; 3irobotix Delta-2A, -2B, -2G, -2A 115000; LDROBOT LD14P; CAMSENSE X1
+paragraph=Supports YDLIDAR X4, X4 PRO, X3, X3 PRO, X2/X2L, SCL; Xiaomi Roborock 1st gen LDS02RR; Neato XV11; SLAMTEC RPLIDAR A1; 3irobotix Delta-2A, -2B, -2G, -2A 115000; LDROBOT LD14P; CAMSENSE X1
 category=Sensors
 url=https://github.com/kaiaai/LDS
 architectures=*

--- a/src/LDS.h
+++ b/src/LDS.h
@@ -39,6 +39,7 @@ class LDS {
       ERROR_INVALID_VALUE = -12,
       ERROR_UNKNOWN = -13,
       ERROR_INVALID_DATA = -14,
+      ERROR_UNAVAILABLE = -15,
     };
 
     enum info_t {
@@ -100,7 +101,7 @@ class LDS {
     virtual String infoCodeToString(info_t code);
     virtual String pinIDToString(lds_pin_t pin);
     virtual String pinStateToString(lds_pin_state_t state);
-    
+
   protected:
     void postScanPoint(float angle_deg, float dist_mm, float quality, bool scan_completed);
     void setMotorPin(float value, lds_pin_t pin);

--- a/src/LDS_YDLIDAR_X4_PRO.cpp
+++ b/src/LDS_YDLIDAR_X4_PRO.cpp
@@ -50,7 +50,6 @@ LDS::result_t LDS_YDLIDAR_X4_PRO::begin() {
   for (int i = 0; i < 16; i++)
     serial_num += String(deviceinfo.serialnum[i] & 0xff, HEX);
   postInfo(INFO_SERIAL_NUMBER, serial_num);
-  delay(100);
 
   /* TODO: Re-enable when getHealth is implemented
   device_health_t healthinfo;
@@ -59,15 +58,12 @@ LDS::result_t LDS_YDLIDAR_X4_PRO::begin() {
   postInfo(INFO_DEVICE_HEALTH, healthinfo.status == 0 ? "OK" : "bad");
   */
 
-  // Start
   startScan();
   return RESULT_OK;
 }
 
 LDS::result_t LDS_YDLIDAR_X4_PRO::start() {
-  init();
-  begin();
-  return RESULT_OK;
+  return startScan();
 }
 
 uint32_t LDS_YDLIDAR_X4_PRO::getSerialBaudRate() {
@@ -99,10 +95,7 @@ void LDS_YDLIDAR_X4_PRO::initMotor() {
 
 void LDS_YDLIDAR_X4_PRO::enableMotor(bool enable) {
   motor_enabled = enable;
-  //setMotorPin(enable ? VALUE_PWM : VALUE_HIGH, LDS_MOTOR_PWM_PIN);
-  // TODO: Re-enable when motor control is implemented
-  //setMotorPin(enable ? VALUE_LOW : VALUE_HIGH, LDS_MOTOR_PWM_PIN);
-  //postInfo(LDS::INFO_OTHER, String(motor_enabled));
+  setMotorPin(enable ? VALUE_PWM : VALUE_HIGH, LDS_MOTOR_PWM_PIN);
 }
 
 bool LDS_YDLIDAR_X4_PRO::isActive() {
@@ -493,8 +486,9 @@ LDS::result_t LDS_YDLIDAR_X4_PRO::getHealth(device_health_t & health, uint32_t t
 
 LDS::result_t LDS_YDLIDAR_X4_PRO::startScan(uint32_t timeout) {
   enableMotor(true);
-  // TODO: Dump the Serial buffer
-  //while (readSerial() >= 0);
+
+  // Clear the serial buffer
+  while (readSerial() >= 0);
 
   if (!power_on_info_processed)
     return ERROR_UNAVAILABLE;

--- a/src/LDS_YDLIDAR_X4_PRO.cpp
+++ b/src/LDS_YDLIDAR_X4_PRO.cpp
@@ -470,7 +470,7 @@ LDS::result_t LDS_YDLIDAR_X4_PRO::getHealth(device_health_t & health) {
   return RESULT_OK;
 }
 
-LDS::result_t LDS_YDLIDAR_X4_PRO::startScan(uint32_t timeout) {
+LDS::result_t LDS_YDLIDAR_X4_PRO::startScan() {
   enableMotor(true);
 
   // Clear the serial buffer

--- a/src/LDS_YDLIDAR_X4_PRO.cpp
+++ b/src/LDS_YDLIDAR_X4_PRO.cpp
@@ -1,0 +1,515 @@
+// Copyright 2023-2024 REMAKE.AI, KAIA.AI, MAKERSPET.COM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on https://github.com/EAIBOT/ydlidar_arduino
+
+#include "LDS_YDLIDAR_X4_PRO.h"
+
+void LDS_YDLIDAR_X4_PRO::init() {
+  ring_start_ms[0] = ring_start_ms[1] = 0;
+  scan_freq_hz = 0;
+  scan_completed = false;
+  initMotor();
+  enableMotor(false);
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::begin() {
+  device_info_t deviceinfo;
+  if (getDeviceInfo(deviceinfo, 500) != RESULT_OK)
+    return ERROR_DEVICE_INFO;
+
+  if (deviceinfo.model == YDLIDAR_X4_PRO_MODEL_NUM) {
+    postInfo(INFO_MODEL, getModelName());
+  } else {
+    postError(ERROR_INVALID_MODEL, String(deviceinfo.model));
+  }
+
+  uint16_t maxv = (uint16_t)(deviceinfo.firmware_version >> 8);
+  uint16_t midv = (uint16_t)(deviceinfo.firmware_version & 0xff) / 10;
+  uint16_t minv = (uint16_t)(deviceinfo.firmware_version & 0xff) % 10;
+  if (midv == 0) {
+    midv = minv;
+    minv = 0;
+  }
+
+  postInfo(INFO_FIRMWARE_VERSION, String(maxv + '.' + midv + '.' + minv));
+  postInfo(INFO_HARDWARE_VERSION, String((uint16_t)deviceinfo.hardware_version));
+
+  String serial_num;
+  for (int i = 0; i < 16; i++)
+    serial_num += String(deviceinfo.serialnum[i] & 0xff, HEX);
+  postInfo(INFO_SERIAL_NUMBER, serial_num);
+  delay(100);
+
+  /* TODO: Re-enable when getHealth is implemented
+  device_health_t healthinfo;
+  if (getHealth(healthinfo, 100) != RESULT_OK)
+    return ERROR_DEVICE_HEALTH;
+  postInfo(INFO_DEVICE_HEALTH, healthinfo.status == 0 ? "OK" : "bad");
+  */
+
+  // Start
+  startScan();
+  return RESULT_OK;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::start() {
+  init();
+  begin();
+  return RESULT_OK;
+}
+
+uint32_t LDS_YDLIDAR_X4_PRO::getSerialBaudRate() {
+  return 128000;
+}
+
+float LDS_YDLIDAR_X4_PRO::getCurrentScanFreqHz() {
+  unsigned long int scan_period_ms = ring_start_ms[0] - ring_start_ms[1];
+  return (!motor_enabled || scan_period_ms == 0) ? 0 : 1000.0f/float(scan_period_ms);
+}
+
+float LDS_YDLIDAR_X4_PRO::getTargetScanFreqHz() {
+  return DEFAULT_VALUE;
+}
+
+int LDS_YDLIDAR_X4_PRO::getSamplingRateHz() {
+  return 5000;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::stop() {
+  if (isActive())
+    abort();
+  return RESULT_OK;
+}
+
+void LDS_YDLIDAR_X4_PRO::initMotor() {
+  setMotorPin(DIR_OUTPUT_PWM, LDS_MOTOR_PWM_PIN);
+}
+
+void LDS_YDLIDAR_X4_PRO::enableMotor(bool enable) {
+  motor_enabled = enable;
+  //setMotorPin(enable ? VALUE_PWM : VALUE_HIGH, LDS_MOTOR_PWM_PIN);
+  // TODO: Re-enable when motor control is implemented
+  //setMotorPin(enable ? VALUE_LOW : VALUE_HIGH, LDS_MOTOR_PWM_PIN);
+  //postInfo(LDS::INFO_OTHER, String(motor_enabled));
+}
+
+bool LDS_YDLIDAR_X4_PRO::isActive() {
+  return motor_enabled;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::setScanTargetFreqHz(float freq) {
+  return freq <= 0 ? RESULT_OK : ERROR_NOT_IMPLEMENTED;
+}
+
+void LDS_YDLIDAR_X4_PRO::markScanTime() {
+  ring_start_ms[1] = ring_start_ms[0];
+  ring_start_ms[0] = millis();
+}
+
+void LDS_YDLIDAR_X4_PRO::checkInfo(int currentByte) {
+  static String s;
+  static uint8_t state = 0;
+  const uint8_t header[] = {0xA5, 0x5A, 0x14, 0x00, 0x00, 0x00, 0x04};
+
+  switch (state) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+    case 6:
+      if (currentByte == header[state]) {
+         state++;
+      } else {
+        state = 0;
+        s = "";
+      }
+      break;
+    case 27:
+      postInfo(INFO_MODEL, s);
+      state = 0;
+      s = "";
+      break;
+    case 7:
+      s = "Model 0x";
+      if (currentByte < 16)
+        s = s + '0';
+      s = s + String(currentByte, HEX);
+      state++;
+      break;
+    case 8:
+      s = s + ", firmware v" + String(currentByte);
+      state++;
+      break;
+    case 9:
+      s = s + '.' + String(currentByte);
+      state++;
+      break;
+    case 10:
+      s = s + ", hardware v" + String(currentByte);
+      state++;
+      break;
+    case 11:
+      s = s + ", S/N " + String(currentByte);
+      state++;
+      break;
+    default:
+      s = s + String(currentByte);
+      state++;
+      break;
+  }
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::waitScanDot() {
+  // TODO: Process interference filtering
+  uint8_t *packageBuffer = (uint8_t*)&package.package_Head;
+
+  switch(state) {
+    case 1:
+      goto state1;
+    case 2:
+      goto state2;
+  }
+
+  if (package_Sample_Index == 0) {
+
+    package_Sample_Num = 0;
+    package_recvPos = 0;
+    recvPos = 0; // Packet start
+
+    // Read in 10-byte packet header
+    while (true) {
+state1:
+      int currentByte = readSerial();
+      if (currentByte < 0) {
+        state = 1;
+        return ERROR_NOT_READY;
+      }
+
+      switch (recvPos) {
+        case 0: // 0xAA 1st byte of package header
+          if (currentByte != (PH&0xFF)) {
+            checkInfo(currentByte);
+            continue;
+          }
+          break;
+        case 1: // 0x55 2nd byte of package header
+          CheckSumCal = PH;
+          if (currentByte != (PH>>8)) {
+            recvPos = 0;
+            continue;
+          }
+          break;
+        case 2:
+          SampleNumlAndCTCal = currentByte;
+          if ((currentByte & 0x01) == CT_RING_START)
+            markScanTime();
+          //if ((currentByte != CT_NORMAL) && (currentByte != CT_RING_START)) {
+          //  recvPos = 0;
+          //  continue;
+          //}
+          break;
+        case 3:
+          SampleNumlAndCTCal += (currentByte<<RESP_MEAS_ANGLE_SAMPLE_SHIFT);
+          package_Sample_Num = currentByte;
+          break;
+        case 4:
+          if (currentByte & RESP_MEAS_CHECKBIT) {
+            FirstSampleAngle = currentByte;
+          } else {
+            recvPos = 0;
+            continue;
+          }
+          break;
+        case 5:
+          FirstSampleAngle += (currentByte<<RESP_MEAS_ANGLE_SAMPLE_SHIFT);
+          CheckSumCal ^= FirstSampleAngle;
+          FirstSampleAngle = FirstSampleAngle>>1;
+          break;
+        case 6:
+          if (currentByte & RESP_MEAS_CHECKBIT) {
+            LastSampleAngle = currentByte;
+          } else {
+            recvPos = 0;
+            continue;
+          }
+          break;
+        case 7:
+          LastSampleAngle += (currentByte<<RESP_MEAS_ANGLE_SAMPLE_SHIFT);
+          LastSampleAngleCal = LastSampleAngle;
+          LastSampleAngle = LastSampleAngle>>1;
+          if (package_Sample_Num == 1) {
+            IntervalSampleAngle = 0;
+          } else {
+            if (LastSampleAngle < FirstSampleAngle) {
+              if ((FirstSampleAngle > 17280) && (LastSampleAngle < 5760)) {
+                IntervalSampleAngle = ((float)(23040 + LastSampleAngle
+                  - FirstSampleAngle))/(package_Sample_Num-1);
+                IntervalSampleAngle_LastPackage = IntervalSampleAngle;
+              } else {
+                IntervalSampleAngle = IntervalSampleAngle_LastPackage;
+              }
+            } else {
+              IntervalSampleAngle = ((float)(LastSampleAngle -FirstSampleAngle))/(package_Sample_Num-1);
+              IntervalSampleAngle_LastPackage = IntervalSampleAngle;
+            }
+          }
+          break;
+        case 8:
+          CheckSum = currentByte;
+          break;
+        case 9:
+          CheckSum += (currentByte<<RESP_MEAS_ANGLE_SAMPLE_SHIFT);
+          break;
+      }
+      packageBuffer[recvPos++] = currentByte;
+
+      if (recvPos == PACKAGE_PAID_BYTES ) {
+        package_recvPos = recvPos;
+        break;
+      }
+    }
+
+    // Check buffer overflow
+    if (package_Sample_Num > PACKAGE_SAMPLE_MAX_LENGTH)
+      return ERROR_INVALID_PACKET;
+
+    if (PACKAGE_PAID_BYTES == recvPos) {
+      // Packet header looks valid size-wise
+      recvPos = 0;
+      package_sample_sum = package_Sample_Num<<1;
+
+      // Read in samples, 2 bytes each
+      while (true) {
+state2:
+        int currentByte = readSerial();
+        if (currentByte < 0){
+          state = 2;
+          return ERROR_NOT_READY;
+        }
+
+        if ((recvPos & 1) == 1) {
+          Valu8Tou16 += (currentByte<<RESP_MEAS_ANGLE_SAMPLE_SHIFT);
+          CheckSumCal ^= Valu8Tou16;
+        } else {
+          Valu8Tou16 = currentByte;
+        }
+
+        packageBuffer[package_recvPos+recvPos] = currentByte;
+        recvPos++;
+        if (package_sample_sum == recvPos) {
+          package_recvPos += recvPos;
+          break;
+        }
+      }
+
+      if (package_sample_sum != recvPos) {
+        state = 0;
+        return ERROR_INVALID_PACKET;
+      }
+    } else {
+      // Packet length is off
+      state = 0;
+      return ERROR_INVALID_PACKET;
+    }
+    CheckSumCal ^= SampleNumlAndCTCal;
+    CheckSumCal ^= LastSampleAngleCal;
+
+    CheckSumResult = CheckSumCal == CheckSum;
+  }
+
+  scan_completed = false;
+  if (CheckSumResult) {
+    scan_completed = (package.package_CT & 0x01) == CT_RING_START;
+    if (scan_completed)
+      //scan_freq = package.package_CT >> 1;
+      //F = CT[bit(7:1)]/10 (when CT[bit(7:1)] = 1).
+      scan_freq_hz = float(package.package_CT >> 1)*0.1f;
+
+    postPacket(packageBuffer, PACKAGE_PAID_BYTES+package_sample_sum, scan_completed);
+  }
+
+  // Process the buffered packet
+  while(true) {
+    node_info_t node;
+
+    node.sync_quality = NODE_DEFAULT_QUALITY;
+
+    if (CheckSumResult == true) {
+      int32_t AngleCorrectForDistance;
+      node.distance_q2 = package.packageSampleDistance[package_Sample_Index];
+
+      if (node.distance_q2/4 != 0) {
+        AngleCorrectForDistance = (int32_t)((atan(((21.8f*(155.3f
+          - (node.distance_q2*0.25f)) )/155.3f)/(node.distance_q2*0.25f)))*3666.93f);
+      } else {
+        AngleCorrectForDistance = 0;
+      }
+
+      float sampleAngle = IntervalSampleAngle*package_Sample_Index;
+
+      if ((FirstSampleAngle + sampleAngle + AngleCorrectForDistance) < 0) {
+        node.angle_q6_checkbit = (((uint16_t)(FirstSampleAngle + sampleAngle
+          + AngleCorrectForDistance + 23040))<<RESP_MEAS_ANGLE_SHIFT)
+          + RESP_MEAS_CHECKBIT;
+      } else {
+        if ((FirstSampleAngle + sampleAngle + AngleCorrectForDistance) > 23040) {
+          node.angle_q6_checkbit = ((uint16_t)((FirstSampleAngle + sampleAngle
+            + AngleCorrectForDistance - 23040))<<RESP_MEAS_ANGLE_SHIFT)
+            + RESP_MEAS_CHECKBIT;
+        } else {
+          node.angle_q6_checkbit = ((uint16_t)((FirstSampleAngle + sampleAngle
+            + AngleCorrectForDistance))<<RESP_MEAS_ANGLE_SHIFT)
+            + RESP_MEAS_CHECKBIT;
+        }
+      }
+    } else {
+      // Invalid checksum
+      //node.sync_quality = NODE_DEFAULT_QUALITY + NODE_NOT_SYNC;
+      node.angle_q6_checkbit = RESP_MEAS_CHECKBIT;
+      node.distance_q2 = 0;
+      package_Sample_Index = 0;
+      state = 0;
+      return ERROR_CHECKSUM;
+    }
+
+    // Dump out processed data
+    float point_distance_mm = node.distance_q2*0.25f;
+    float point_angle = (node.angle_q6_checkbit >> RESP_MEAS_ANGLE_SHIFT)*0.015625f; // /64.0f
+    //uint8_t point_quality = (node.sync_quality>>RESP_MEAS_QUALITY_SHIFT);
+    uint8_t point_quality = node.sync_quality;
+    //bool point_startBit = (node.sync_quality & RESP_MEAS_SYNCBIT);
+
+    //postScanPoint(point_angle, point_distance_mm, point_quality, point_startBit);
+    postScanPoint(point_angle, point_distance_mm, point_quality, scan_completed);
+    scan_completed = false;
+
+    // Dump finished?
+    package_Sample_Index++;
+    uint8_t nowPackageNum = package.nowPackageNum;
+    if (package_Sample_Index >= nowPackageNum) {
+      package_Sample_Index = 0;
+      break;
+    }
+  }
+  state = 0;
+  return LDS::RESULT_OK;
+}
+
+void LDS_YDLIDAR_X4_PRO::loop() {
+  while (true) {
+    result_t result = waitScanDot();
+    if (result == ERROR_NOT_READY)
+      break;
+    if (result < RESULT_OK)
+      postError(result, "");
+  }
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::abort() {
+  enableMotor(false);
+  return RESULT_OK;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::getDeviceInfo(device_info_t & info, uint32_t timeout) {
+  if (power_on_info_processed)
+    return ERROR_UNAVAILABLE;
+
+  uint8_t recvPos = 0;
+  uint32_t currentTs = millis();
+  uint8_t *infobuf = (uint8_t*)&info;
+
+  ans_header_t response_header;
+  LDS::result_t ans = waitMessageHeader(&response_header, timeout);
+  if (ans != RESULT_OK)
+    return ans;
+
+  if (response_header.type != ANS_TYPE_DEV_INFO)
+    return ERROR_INVALID_PACKET;
+
+  if (response_header.size < sizeof(ans_header_t))
+    return ERROR_INVALID_PACKET;
+
+  while ((millis() - currentTs) <= timeout) {
+    int current_byte = readSerial();
+    if (current_byte < 0)
+      continue;
+    infobuf[recvPos++] = current_byte;
+
+    if (recvPos == sizeof(device_info_t)) {
+      power_on_info_processed = true;
+      return RESULT_OK;
+    }
+  }
+
+  return ERROR_TIMEOUT;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::waitMessageHeader(ans_header_t * header, uint32_t timeout) {
+  int recvPos = 0;
+  uint32_t startTs = millis();
+  uint8_t *headerBuffer = (uint8_t *)header;
+
+  while ((millis() - startTs) <= timeout) {
+    int current_byte = readSerial();
+    if (current_byte < 0)
+      continue;
+
+    switch (recvPos) {
+      case 0:
+        if (current_byte != ANS_SYNC_BYTE1)
+          continue;
+        break;
+      case 1:
+        if (current_byte != ANS_SYNC_BYTE2) {
+            recvPos = 0;
+            continue;
+        }
+        break;
+    }
+    headerBuffer[recvPos++] = current_byte;
+
+    if (recvPos == sizeof(ans_header_t))
+      return RESULT_OK;
+  }
+  return ERROR_TIMEOUT;
+}
+LDS::result_t LDS_YDLIDAR_X4_PRO::getHealth(device_health_t & health, uint32_t timeout) {
+  return ERROR_NOT_IMPLEMENTED;
+}
+
+LDS::result_t LDS_YDLIDAR_X4_PRO::startScan(uint32_t timeout) {
+  enableMotor(true);
+  // TODO: Dump the Serial buffer
+  //while (readSerial() >= 0);
+
+  if (!power_on_info_processed)
+    return ERROR_UNAVAILABLE;
+
+  ans_header_t response_header;
+  LDS::result_t ans = waitMessageHeader(&response_header, timeout);
+  if (ans != RESULT_OK)
+    return ans;
+
+  if (response_header.type != ANS_TYPE_MEAS)
+    return ERROR_INVALID_PACKET;
+
+  if (response_header.size < sizeof(node_info_t))
+    return ERROR_INVALID_PACKET;
+  return RESULT_OK;
+}
+
+const char* LDS_YDLIDAR_X4_PRO::getModelName() { return "YDLIDAR X4 PRO"; }

--- a/src/LDS_YDLIDAR_X4_PRO.h
+++ b/src/LDS_YDLIDAR_X4_PRO.h
@@ -38,7 +38,7 @@ class LDS_YDLIDAR_X4_PRO : public LDS {
     virtual result_t setScanTargetFreqHz(float freq) override;
 
   protected:
-    bool motor_enabled;
+    bool motor_enabled = false;
     unsigned long int ring_start_ms[2];
     bool power_on_info_processed = false;
 

--- a/src/LDS_YDLIDAR_X4_PRO.h
+++ b/src/LDS_YDLIDAR_X4_PRO.h
@@ -55,7 +55,7 @@ class LDS_YDLIDAR_X4_PRO : public LDS {
     struct node_info_t {
       uint8_t    sync_quality;
       uint16_t   angle_q6_checkbit;
-      uint16_t   distance_q2;
+      uint16_t   distance;
     } __attribute__((packed)) ;
 
     struct device_info_t{
@@ -78,6 +78,12 @@ class LDS_YDLIDAR_X4_PRO : public LDS {
       uint8_t  type;
     } __attribute__((packed));
 
+    struct distance_measurement_t {
+      uint8_t   packageInterference:2;
+      uint8_t   packageDistanceLByte:6;
+      uint8_t   packageDistanceHByte;
+    } __attribute__((packed)) ;
+
     struct node_package_t {
       uint16_t  package_Head;
       uint8_t   package_CT; // package type
@@ -85,7 +91,7 @@ class LDS_YDLIDAR_X4_PRO : public LDS {
       uint16_t  packageFirstSampleAngle;
       uint16_t  packageLastSampleAngle;
       uint16_t  checkSum;
-      uint16_t  packageSampleDistance[PACKAGE_SAMPLE_MAX_LENGTH]; // SCL hack
+      distance_measurement_t packageSampleDistance[PACKAGE_SAMPLE_MAX_LENGTH];
     } __attribute__((packed)) ;
 
   protected:

--- a/src/LDS_YDLIDAR_X4_PRO.h
+++ b/src/LDS_YDLIDAR_X4_PRO.h
@@ -1,0 +1,151 @@
+// Copyright 2023-2024 REMAKE.AI, KAIA.AI, MAKERSPET.COM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Based on https://github.com/EAIBOT/ydlidar_arduino
+
+#pragma once
+#include "LDS.h"
+
+#define YDLIDAR_X4_PRO_MODEL_NUM 4
+
+class LDS_YDLIDAR_X4_PRO : public LDS {
+  public:
+    virtual void init() override;
+    result_t begin();
+
+    virtual result_t start() override;
+    virtual result_t stop() override;
+    virtual void loop() override; // Call loop() frequently from Arduino loop()
+
+    virtual uint32_t getSerialBaudRate() override;
+    virtual float getCurrentScanFreqHz() override;
+    virtual float getTargetScanFreqHz() override;
+    virtual int getSamplingRateHz() override;
+    virtual bool isActive() override;
+    virtual const char* getModelName() override;
+
+    virtual result_t setScanTargetFreqHz(float freq) override;
+
+  protected:
+    bool motor_enabled;
+    unsigned long int ring_start_ms[2];
+    bool power_on_info_processed = false;
+
+  protected:
+    static const uint32_t DEFAULT_TIMEOUT_MS = 500;
+    static const uint8_t PACKAGE_SAMPLE_MAX_LENGTH = 40;
+
+    typedef enum {
+      CT_NORMAL = 0,
+      CT_RING_START = 1,
+      CT_TAIL,
+    } CT;
+
+    struct node_info_t {
+      uint8_t    sync_quality;
+      uint16_t   angle_q6_checkbit;
+      uint16_t   distance_q2;
+    } __attribute__((packed)) ;
+
+    struct device_info_t{
+      uint8_t   model;
+      uint16_t  firmware_version;
+      uint8_t   hardware_version;
+      uint8_t   serialnum[16];
+    } __attribute__((packed)) ;
+
+    struct device_health_t {
+      uint8_t   status;
+      uint16_t  error_code;
+    } __attribute__((packed))  ;
+
+    struct ans_header_t {
+      uint8_t  syncByte1;
+      uint8_t  syncByte2;
+      uint32_t size:30;
+      uint32_t subType:2;
+      uint8_t  type;
+    } __attribute__((packed));
+
+    struct node_package_t {
+      uint16_t  package_Head;
+      uint8_t   package_CT; // package type
+      uint8_t   nowPackageNum; // distance sample count
+      uint16_t  packageFirstSampleAngle;
+      uint16_t  packageLastSampleAngle;
+      uint16_t  checkSum;
+      uint16_t  packageSampleDistance[PACKAGE_SAMPLE_MAX_LENGTH]; // SCL hack
+    } __attribute__((packed)) ;
+
+  protected:
+    void initMotor();
+    virtual void enableMotor(bool enable);
+    LDS::result_t getHealth(device_health_t & health, uint32_t timeout = DEFAULT_TIMEOUT_MS);
+    LDS::result_t getDeviceInfo(device_info_t & info, uint32_t timeout = DEFAULT_TIMEOUT_MS);
+    LDS::result_t abort();
+    LDS::result_t startScan(uint32_t timeout = DEFAULT_TIMEOUT_MS);
+    virtual LDS::result_t waitScanDot(); // wait for one sample package to arrive
+    LDS::result_t waitMessageHeader(ans_header_t * header, uint32_t timeout = DEFAULT_TIMEOUT_MS);
+    void markScanTime();
+    void checkInfo(int currentByte);
+
+  protected:
+    // Scan start packet: 2 bytes
+    // Samples: 16 packets, up to 90B each total
+    //   10 bytes header + 40*2=70 bytes samples
+    // At 7Hz max total 1,442 bytes per scan
+    static const uint8_t ANS_TYPE_DEV_INFO = 0x4;
+    static const uint8_t ANS_TYPE_DEV_HEALTH = 0x6;
+    static const uint8_t ANS_SYNC_BYTE1 = 0xA5;
+    static const uint8_t ANS_SYNC_BYTE2 = 0x5A;
+    static const uint8_t ANS_TYPE_MEAS = 0x81;
+
+    static const uint8_t RESP_MEAS_SYNCBIT = (0x1<<0);
+    //static const uint8_t RESP_ MEAS_QUALITY_SHIFT = 2;
+    static const uint8_t RESP_MEAS_CHECKBIT = (0x1<<0);
+    static const uint8_t RESP_MEAS_ANGLE_SHIFT = 1;
+    static const uint8_t RESP_MEAS_ANGLE_SAMPLE_SHIFT = 8;
+
+    static const uint8_t PACKAGE_SAMPLE_BYTES = 2;
+    static const uint16_t NODE_DEFAULT_QUALITY = 10; // (10<<2)
+    static const uint8_t NODE_SYNC = 0x01;
+    static const uint8_t NODE_NOT_SYNC = 2;
+    static const uint8_t PACKAGE_PAID_BYTES = 10;
+    static const uint16_t PH = 0x55AA; // Packet Header
+
+    int recvPos = 0;
+    uint8_t package_Sample_Num = 0;
+    int package_recvPos = 0;
+    int package_sample_sum = 0;
+
+    node_package_t package;
+
+    uint16_t package_Sample_Index = 0;
+    float IntervalSampleAngle = 0;
+    float IntervalSampleAngle_LastPackage = 0;
+    uint16_t FirstSampleAngle = 0;
+    uint16_t LastSampleAngle = 0;
+    uint16_t CheckSum = 0;
+
+    uint16_t CheckSumCal = 0;
+    uint16_t SampleNumlAndCTCal = 0;
+    uint16_t LastSampleAngleCal = 0;
+    bool CheckSumResult = true;
+    uint16_t Valu8Tou16 = 0;
+
+    uint8_t state = 0;
+
+    float scan_freq_hz = 0;
+    bool scan_completed = false;
+};

--- a/src/LDS_YDLIDAR_X4_PRO.h
+++ b/src/LDS_YDLIDAR_X4_PRO.h
@@ -110,7 +110,7 @@ class LDS_YDLIDAR_X4_PRO : public LDS {
     void initMotor();
     virtual void enableMotor(bool enable);
     LDS::result_t abort();
-    LDS::result_t startScan(uint32_t timeout = DEFAULT_TIMEOUT_MS);
+    LDS::result_t startScan();
     virtual LDS::result_t waitScanDot(); // wait for one sample package to arrive
     LDS::result_t waitMessageHeader(ans_header_t * header, uint32_t timeout = DEFAULT_TIMEOUT_MS);
     void markScanTime();


### PR DESCRIPTION
This PR adds a full implementation of the YDLIDAR X4 Pro. The majority of the code is similar to the X4's, except that the X4 Pro has no RX line. Commands are not supported. Additional X4 Pro-specific features implemented include interference flags (under the "quality" of a given reading) and CT packet scanning (provides device and health info).

I have tested all of the functionality and it appears to work as expected.